### PR TITLE
Publish standard messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,15 +48,13 @@ mqtt = Mqtt(
 # Main loop
 cnt = 0
 while True:
-    print("..")
-
     # Get messages from mqtt topics
     mqtt.check_msg()
 
     # Send test messages periodically to mqtt topic
     cnt += 1
-    if cnt == 10:
-        mqtt.publish(f"Counter {cnt}")
+    if cnt == 4:
+        mqtt.publish(f"DATA client_id={config.MQTT_CLIENT_ID} time={time.time()}")
         cnt = 0
 
     # Wait

--- a/paniq_prop/mqtt.py
+++ b/paniq_prop/mqtt.py
@@ -69,8 +69,8 @@ class Mqtt():
                     print(f"Subscribing to topic: {topic}")
                     self._client.subscribe(topic)
 
-                self.publish(f"CONNECTED [{self.client_id}]")
                 self.status = self.STAT_CONNECTED
+                self.publish(f"CONNECTED client_id={self.client_id}")
 
                 print("Mqtt connection established")
                 if self.statusLed:


### PR DESCRIPTION
xcape room server gives error messages on published messages:

```
00:49:46.200 [WifiProp1] Unexpected MQTT message : <some messages>
```

Publish xcape compatible message  payloads (`CONNECTED`, `DATA` prefixes with key-value pairs) that do not send warnings:
```
00:48:13.514 CONNECTED client_id=Raspberry PI Pico W 1
00:48:16.356 DATA client_id=Raspberry PI Pico W 1 time=1667177296
```