### PR TITLE
Add logger

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,10 @@
 # MQTT topic names to publish and receive messages will be deri this name
 PROP_NAME = "Prop1"
 
+# Logfile name. Set an empty string to disable logging to file
+# Log file max size is 1kb. Old logs are deleted automatically
+LOG_FILE = ""
+
 # Status leds
 NETWORK_STATUS_PIN = 4
 MQTT_STATUS_PIN = 5

--- a/lib/ulogger/__init__.py
+++ b/lib/ulogger/__init__.py
@@ -1,0 +1,323 @@
+# This is a modified version of micropython-ulogger 1.2 at https://pypi.org/project/micropython-ulogger/
+# Removing the functionality to log to files as some supported paniq-room board firmwares
+# are not including TextIOWrapper which makes logging to file not possible
+try:    import time
+except: import utime as time
+
+try:    from micropython import const
+except: const = lambda x:x # for debug
+
+# from io import TextIOWrapper
+
+__version__ = "v1.2"
+
+DEBUG:    int = const(10)
+INFO:     int = const(20)
+WARN:     int = const(30)
+ERROR:    int = const(40)
+CRITICAL: int = const(50)
+
+TO_FILE = const(100)
+TO_TERM = const(200)
+
+# fmt map 的可选参数
+_level  = const(0)
+_msg    = const(1)
+_time   = const(2)
+_name   = const(3)
+_fnname = const(4)
+
+
+def level_name(level: int, color: bool = False) -> str:
+    if not color:
+        if level == INFO:
+            return "INFO"
+        elif level == DEBUG:
+            return "DEBUG"
+        elif level == WARN:
+            return "WARN"
+        elif level == ERROR:
+            return "ERROR"
+        elif level == CRITICAL:
+            return "CRITICAL"
+    else:
+        if level == INFO:
+            return "\033[97mINFO\033[0m"
+        elif level == DEBUG:
+            return "\033[37mDEBUG\033[0m"
+        elif level == WARN:
+            return "\033[93mWARN\033[0m"
+        elif level == ERROR:
+            return "\033[35mERROR\033[0m"
+        elif level == CRITICAL:
+            return "\033[91mCRITICAL\033[0m"
+
+
+class BaseClock ():
+    """
+    This is a BaseClock for the logger.
+    Please inherit this class by your custom.
+    """
+
+    def __call__(self) -> str:
+        """
+        Acquire the time of now, please inherit this method.
+        We will use the return value of this function as the time format of the log,
+        such as `2021 - 6 - 13` or `12:45:23` and so on.
+
+        :return: the time string.
+        """
+        return '%d' % time.time()
+
+
+class Handler():
+    """The Handler for logger.
+    """
+    _template: str
+    _map: bytes
+    level: int
+    _direction: int
+    _clock: BaseClock
+    _color: bool
+    _file_name: str
+    _max_size: int
+    # _file = TextIOWrapper
+
+    def __init__(self,
+        level: int = INFO,
+        colorful: bool = True,
+        fmt: str = "&(time)% - &(level)% - &(name)% - &(msg)%",
+        clock: BaseClock = None,
+        direction: int = TO_TERM,
+        file_name: str = "logging.log",
+        max_file_size: int = 4096
+        ):
+        """
+        Create a Handler that you can add to the logger later
+
+        ## Options available for fmt.
+        - &(level)%  : the log level
+        - &(msg)%    : the log message
+        - &(time)%   : the time acquire from clock, see `BaseClock`
+        - &(name)%   : the logger's name
+        - &(fnname)%  : the function name which you will pass on.
+        - more optional is developing.
+
+        ## Options available for level.
+        - DEBUG
+        - INFO
+        - WARN
+        - ERROR
+        - CRITICAL
+
+        ## Options available for direction.
+        - TO_FILE : output to a file
+        - TO_TERM : output to terminal
+
+        :param level: Set a minimum level you want to be log
+        :type level: int(see the consts in this module)
+
+        :param colorful: Whether to use color display information to terminal(Not applicable to files)
+        :type colorful: bool
+
+        :param fmt: the format string like: "&(time)% - &(level)% - &(name)% - &(fnname)% - &(msg)%"(default)
+        :type fmt: str
+
+        :param clock: The Clock which will provide time str. see `BaseClock`
+        :type clock: BaseClock(can be inherit )
+
+        :param direction: Set the direction where logger will output
+        :type direction: int (`TO_FILE` or `TO_TERM`)
+
+        :param file_name: available when you set `TO_FILE` to param `direction`. (default for `logging.log`)
+        :type file_name: str
+        :param max_file_size: available when you set `TO_FILE` to param `direction`. The unit is `byte`, (default for 4k)
+        :type max_file_size: str
+        """
+        #TODO: 文件按日期存储, 最大份数的设置.
+        self._direction = direction
+        self.level = level
+        self._clock = clock if clock else BaseClock()
+        self._color = colorful
+        self._file_name = file_name if direction == TO_FILE else ''
+        self._max_size = max_file_size if direction == TO_FILE else 0
+
+        if direction == TO_FILE:
+            self._file = open(file_name, 'a+')
+
+        # 特么的re居然不能全局匹配, 烦了, 只能自己来.
+        # m = re.match(r"&\((.*?)\)%", fmt)
+        # i = 0
+        # while True:
+        #     # 由于蛋疼的 ure 不能直接获取匹配结果的数量, 只能使用这种蠢蛋方法来循环.
+        #     try:
+        #         text = m.group(i)
+
+        #     except:
+        #         # 发生错误说明已经遍历完毕
+        #         break
+
+        #     # 使用指针代替文本来减少开销
+        #     if text == "level":
+        #         self._map.append(_level)
+        #     elif text == "msg":
+        #         self._map.append(_msg)
+        #     elif text == "time":
+        #         self._map.append(_time)
+        #     elif text == "name":
+        #         self._map.append(_name)
+        #     elif text == "fnname":
+        #         self._map.append(_fnname)
+
+        #     i += 1
+
+        # 添加映射
+        self._map = bytearray()
+        idx = 0
+        while True:
+            idx = fmt.find("&(", idx)
+            if idx >= 0:  # 有找到
+                a_idx = fmt.find(")%", idx+2)
+                if a_idx < 0:
+                    # 没找到后缀, 报错
+                    raise Exception(
+                        "Unable to parse text format successfully.")
+                text = fmt[idx+2:a_idx]
+                idx = a_idx+2  # 交换位置
+                if text == "level":
+                    self._map.append(_level)
+                elif text == "msg":
+                    self._map.append(_msg)
+                elif text == "time":
+                    self._map.append(_time)
+                elif text == "name":
+                    self._map.append(_name)
+                elif text == "fnname":
+                    self._map.append(_fnname)
+            else:  # 没找到, 代表后面没有了
+                break
+
+        # 将 template 变成可被格式化的文本
+        # 确保最后一个是换行字符
+
+        self._template = fmt.replace("&(level)%", "%s")\
+            .replace("&(msg)%", "%s")\
+            .replace("&(time)%", "%s")\
+            .replace("&(name)%", "%s")\
+            .replace("&(fnname)%", "%s")\
+            + "\n" if fmt[:-1] != '\n' else ''
+
+    def _msg(self, *args, level: int, name: str, fnname: str):
+        """
+        Log a msg
+        """
+        
+        if level < self.level:
+            return
+        # generate msg
+        temp_map = []
+        text = ''
+        for item in self._map:
+            if item == _msg:
+                for text_ in args:  # 将元组内的文本添加到一起
+                    text = "%s%s" % (text, text_)  # 防止用户输入其他类型(int, float)
+                temp_map.append(text)
+            elif item == _level:
+                if self._direction == TO_TERM:  # only terminal can use color.
+                    temp_map.append(level_name(level, self._color))
+                else:
+                    temp_map.append(level_name(level))
+            elif item == _time:
+                temp_map.append(self._clock())
+            elif item == _name:
+                temp_map.append(name)
+            elif item == _fnname:
+                temp_map.append(fnname if fnname else "unknownfn")
+
+        if self._direction == TO_TERM:
+            self._to_term(tuple(temp_map))
+        else:
+            self._to_file(tuple(temp_map))
+        # TODO: 待验证: 转换为 tuple 和使用 fromat 谁更快
+
+    def _to_term(self, map: tuple):
+        print(self._template % map, end='')
+
+    def _to_file(self, map: tuple):
+        fp = self._file
+        # 检查是否超出大小限制.
+        prev_idx = fp.tell()  # 保存原始指针位置
+        # 将读写指针跳到文件最大限制的地方,
+        # 如果能读出数据, 说明文件大于指定的大小
+        fp.seek(self._max_size)
+        if fp.read(1):  # 能读到数据, 说明超出大小限制了
+            fp = self._file = open(self._file_name, 'w')  # 使用 w 选项清空文件内容
+        else:
+            # 没有超出限制
+            fp.seek(prev_idx)  # 指针回到原来的地方
+
+        # 检查完毕, 开始写入数据
+        fp.write(self._template % map)
+        fp.flush()
+
+
+class Logger():
+    _handlers: list
+
+    def __init__(self,
+        name: str,
+        handlers: list = None,
+        ):
+
+        self.name = name
+        if not handlers:
+            # 如果没有指定处理器, 自动创建一个默认的
+            self._handlers = [Handler()]
+        else:
+            self._handlers = handlers
+
+    @property
+    def handlers(self):
+        return self._handlers
+
+    def _msg(self, *args, level: int, fn: str):
+
+        for item in self._handlers:
+            #try:
+            item._msg(*args, level=level, fnname=fn, name=self.name)
+            #except:
+            #    print("Failed while trying to record")
+
+    def debug(self, *args, fn: str = None):
+        self._msg(*args, level=DEBUG, fn=fn)
+
+    def info(self, *args, fn: str = None):
+        self._msg(*args, level=INFO, fn=fn)
+
+    def warn(self, *args, fn: str = None):
+        self._msg(*args, level=WARN, fn=fn)
+
+    def error(self, *args, fn: str = None):
+        self._msg(*args, level=ERROR, fn=fn)
+
+    def critical(self, *args, fn: str = None):
+        self._msg(*args, level=CRITICAL, fn=fn)
+
+
+__all__ = [
+    Logger,
+    Handler,
+    BaseClock,
+
+
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    CRITICAL,
+
+    TO_FILE,
+    TO_TERM,
+
+    __version__
+]

--- a/paniq_prop/logger.py
+++ b/paniq_prop/logger.py
@@ -1,0 +1,66 @@
+import config
+import time
+import ulogger
+
+
+class Iso8601Clock():
+    """
+    This is a Iso8601Clock for the logger.
+
+    Converts the time secs expressed in seconds since the Epoch
+    to ISO8601 format
+    """
+
+    def __call__(self) -> str:
+        gm_time = time.gmtime()
+        return f"{gm_time[0]}-{gm_time[1]}-{gm_time[2]} {gm_time[3]}:{gm_time[4]}:{gm_time[5]}"
+
+if config.LOG_FILE:
+    handler_to_file = ulogger.Handler(
+        level=ulogger.INFO,
+        fmt="&(time)% - &(level)% - &(name)% - &(msg)%",
+        clock=Iso8601Clock(),
+        direction=ulogger.TO_FILE,
+        file_name=config.LOG_FILE,
+        max_file_size=1024 # max for 1k
+    )
+else:
+    handler_to_file = None
+
+
+class Logger():
+    def __init__(
+        self,
+        name: str,
+        to_file: bool = True,
+        ):
+
+        handler_to_term = ulogger.Handler(
+            level=ulogger.INFO,
+            colorful=False,
+            fmt="&(time)% - &(level)% - &(name)% - &(msg)%",
+            clock=Iso8601Clock(),
+            direction=ulogger.TO_TERM,
+        )
+
+        handlers = [handler_to_term]
+        
+        if handler_to_file:
+            handlers.append(handler_to_file)
+
+        self._ulogger = ulogger.Logger(name=name, handlers=handlers)
+
+    def debug(self, *args, fn: str = None):
+        self._ulogger.debug(*args, fn=fn)
+
+    def info(self, *args, fn: str = None):
+        self._ulogger.info(*args, fn=fn)
+
+    def warn(self, *args, fn: str = None):
+        self._ulogger.warn(*args, fn=fn)
+
+    def error(self, *args, fn: str = None):
+        self._ulogger.error(*args, fn=fn)
+
+    def critical(self, *args, fn: str = None):
+        self._ulogger.critical(*args, fn=fn)

--- a/paniq_prop/mqtt.py
+++ b/paniq_prop/mqtt.py
@@ -1,7 +1,11 @@
 from machine import Timer
 from umqtt.simple import MQTTClient
 
+from paniq_prop.logger import Logger
 from paniq_prop.status_leds import StatusLed
+
+logger = Logger(__name__)
+
 
 class Mqtt():
     STAT_NOT_CONNECTED = 0
@@ -58,7 +62,7 @@ class Mqtt():
 
     def connect(self):
         if self.status == self.STAT_NOT_CONNECTED:
-            print(f"Connecting to mqtt broker at {self.server}:{self.port}...")
+            logger.info(f"Connecting to mqtt broker at {self.server}:{self.port}...")
             try:
                 self.status = self.STAT_CONNECTING
 
@@ -69,22 +73,22 @@ class Mqtt():
                 self._client.set_callback(self.on_message)
 
                 for topic in self.topics:
-                    print(f"Subscribing to topic: {topic}")
+                    logger.info(f"Subscribing to topic: {topic}")
                     self._client.subscribe(topic)
 
                 self.status = self.STAT_CONNECTED
                 self.publish(f"CONNECTED client_id={self.client_id}")
 
-                print("Mqtt connection established")
+                logger.info("Mqtt connection established")
                 if self.statusLed:
                     self.statusLed.on()
             except OSError as e:
-                print(f"Failed to connect to MQTT broker. {e}")
+                logger.error(f"Failed to connect to MQTT broker. {e}")
                 self.status = self.STAT_NOT_CONNECTED
                 if self.statusLed:
                     self.statusLed.off()
         elif self.status == self.STAT_CONNECTED:
-            print("Mqtt connected")
+            logger.info("Mqtt connected")
             if self.statusLed:
                 self.statusLed.on()
 
@@ -107,7 +111,7 @@ class Mqtt():
     def _default_on_message(self, b_topic: str, b_msg: str, retained: bool, dup: bool):
         topic = b_topic.decode('utf-8')
         msg = b_msg.decode('utf-8')
-        print(f"Message received from {topic} (retained: {retained}) (dup: {dup}): {msg}")
+        logger.info(f"Message received from {topic} (retained: {retained}) (dup: {dup}): {msg}")
 
     def publish(self, msg: str):
         if self.isconnected():

--- a/paniq_prop/network.py
+++ b/paniq_prop/network.py
@@ -1,8 +1,11 @@
 import network
 
+from paniq_prop.logger import Logger
 from paniq_prop.status_leds import StatusLed
 from paniq_prop.network_adapters.ethernet import EthernetNetworkAdapter
 from paniq_prop.network_adapters.wifi import WifiNetworkAdapter
+
+logger = Logger(__name__)
 
 
 class Network():
@@ -46,7 +49,7 @@ class Network():
                 if network.WLAN:
                     self.network_adapter_class = WifiNetworkAdapter
             except AttributeError:
-                print("Not found a supported network device.")
+                logger.critical("Not found a supported network device.")
         
     def init_network_adapter(self):
         if self.network_adapter_class == WifiNetworkAdapter:
@@ -65,17 +68,17 @@ class Network():
                 dns=self.eth_dns,
             )
         else:
-            print("Cannot initialise network without a supported network adapter.")
+            logger.critical("Cannot initialise network without a supported network adapter.")
 
     def connect(self):
         if self.network_adapter_class:
-            print(f"Connecting network using {self.network_adapter_class.__name__} adapter...")        
+            logger.info(f"Connecting network using {self.network_adapter_class.__name__} adapter...")
             if self.network_adapter:
                 self.network_adapter.connect()
             else:
-                print("Network adapter class not initialised")
+                logger.critical("Network adapter class not initialised")
         else:
-            print("Network adapter class not defined")
+            logger.critical("Network adapter class not defined")
     
     def disconnect(self):
         if self.network_adapter:

--- a/paniq_prop/network_adapters/ethernet.py
+++ b/paniq_prop/network_adapters/ethernet.py
@@ -5,7 +5,11 @@ from machine import Pin
 from machine import SPI
 from machine import Timer
 
+from paniq_prop.logger import Logger
 from paniq_prop.status_leds import StatusLed
+
+logger = Logger(__name__)
+
 
 class EthernetNetworkAdapter():
     STAT_NOT_CONNECTED = 0
@@ -50,7 +54,7 @@ class EthernetNetworkAdapter():
     def connect(self):
         if not self.isconnected():
             if self.status != self.STAT_CONNECTING:
-                print("Connecting to Ethernet LAN...")
+                logger.info("Connecting to Ethernet LAN...")
                 self.status = self.STAT_CONNECTING
 
                 if self.statusLed:
@@ -58,13 +62,13 @@ class EthernetNetworkAdapter():
                 
                 self.nic.ifconfig((self.ip, self.subnet, self.gateway, self.dns))
         else:
-            print(f"Ethernet connected: {self.nic.ifconfig()}")
+            logger.info(f"Ethernet connected: {self.nic.ifconfig()}")
             self.status = self.STAT_CONNECTED
             if self.statusLed:
                 self.statusLed.on()
 
     def disconnect(self):
-        print("Disconnect ETH WIZNET5K not implemented")
+        logger.warning("Disconnect ETH WIZNET5K not implemented")
 
     def isconnected(self):
         return self.nic.isconnected()

--- a/paniq_prop/network_adapters/wifi.py
+++ b/paniq_prop/network_adapters/wifi.py
@@ -1,7 +1,11 @@
 import network
 from machine import Timer
 
+from paniq_prop.logger import Logger
 from paniq_prop.status_leds import StatusLed
+
+logger = Logger(__name__)
+
 
 class WifiNetworkAdapter():
     def __init__(
@@ -33,13 +37,13 @@ class WifiNetworkAdapter():
     def connect(self):
         if not self.wlan.isconnected():
             if self.wlan.status() != network.STAT_CONNECTING:
-                print("Connecting to wifi...")
+                logger.info("Connecting to wifi...")
                 if self.statusLed:
                     self.statusLed.blink()
 
                 self.wlan.connect(self.ssid, self.password)
         else:
-            print("Wifi connected")
+            logger.info("Wifi connected")
             if self.statusLed:
                 self.statusLed.on()
 

--- a/paniq_prop/status_leds.py
+++ b/paniq_prop/status_leds.py
@@ -3,6 +3,10 @@ import time
 from machine import Pin
 from machine import Timer
 
+from paniq_prop.logger import Logger
+
+logger = Logger(__name__)
+
 
 class StatusLed():
     STAT_OFF = 0
@@ -62,3 +66,5 @@ class StatusLeds():
 
         self.network.off()
         self.mqtt.off()
+
+        logger.info("Status leds reset")


### PR DESCRIPTION
Add configurable logger lib instead of writing directly to terminal.

It's using [micropython-ulogger](https://github.com/whales-chen/micropython-ulogger) and by default it is logging to terminal only. Optionally if `LOG_FILE` is set in the `config.py` then it logs to a file on the microcontroller in parallel. If `LOG_FILE` is enabled then it keeps up to 1KB log on the board and deletes old messages automatically.

Example output:
```
2022-10-31 14:6:32 - INFO - paniq_prop.status_leds - Status leds reset
2022-10-31 14:6:32 - INFO - paniq_prop.network - Connecting network using WifiNetworkAdapter adapter...
2022-10-31 14:6:32 - INFO - paniq_prop.network_adapters.wifi - Wifi connected
2022-10-31 14:6:32 - INFO - paniq_prop.mqtt - Connecting to mqtt broker at 192.168.1.66:1883...
2022-10-31 14:6:33 - INFO - paniq_prop.mqtt - Subscribing to topic: Room/TestRoom/Control/game:players
2022-10-31 14:6:33 - INFO - paniq_prop.mqtt - Subscribing to topic: Room/TestRoom/Control/game:scenario
2022-10-31 14:6:33 - INFO - paniq_prop.mqtt - Subscribing to topic: Room/TestRoom/Control/game:countdown:seconds
2022-10-31 14:6:33 - INFO - paniq_prop.mqtt - Subscribing to topic: Room/TestRoom/Props/WifiProp1/inbox
2022-10-31 14:6:33 - INFO - paniq_prop.mqtt - Mqtt connection established
```