### PR TITLE
Send PONG to room server @PING request

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,16 +34,18 @@ MQTT_SERVER_KEEPALIVE = 60
 # Make the MQTT client ID unique across all the props
 MQTT_CLIENT_ID = "Wiznet W5100S-EVB-Pico ETH 1"
 
-# Topics to receive messages from
+# Common topics
 MQTT_TOPIC_PREFIX = "Room/TestRoom"
+MQTT_TOPIC_PROP_INBOX = f"{MQTT_TOPIC_PREFIX}/Props/{PROP_NAME}/inbox"
+
+# Topics to receive messages from
 MQTT_TOPICS_TO_SUBSCRIBE = [
     # Subscribe to topics with room server control messages
     f"{MQTT_TOPIC_PREFIX}/Control/game:players",
     f"{MQTT_TOPIC_PREFIX}/Control/game:scenario",
-    f"{MQTT_TOPIC_PREFIX}/Control/game:countdown:seconds",
 
-    # Subscribe to the topic with messages sent to this prop from other ones
-    f"{MQTT_TOPIC_PREFIX}/Props/{PROP_NAME}/inbox",
+    # Subscribe to the prop's own inbox topic
+    MQTT_TOPIC_PROP_INBOX,
 ]
 
 # Topics to send messages to. Make it unique across all the props

--- a/main.py
+++ b/main.py
@@ -43,6 +43,7 @@ mqtt = Mqtt(
     keepalive=config.MQTT_SERVER_KEEPALIVE,
     connection_check_period=config.MQTT_CONNECTION_CHECK_PERIOD,
 
+    inbox_topic=config.MQTT_TOPIC_PROP_INBOX,
     # Set on_message if custom message receiver needed
     # on_message=on_mqtt_message,
 )


### PR DESCRIPTION
Xcape.io room server is sending `@PING` requests to props in every minute. The props are expected to send `PONG` messages so the room server can measure the connection speed.

Add `@PING-PONG` handler to default `paniq_prop.mqtt` message handler. The measured connection is visible on the Room Server dashboard:

![image](https://user-images.githubusercontent.com/643687/199032961-3e7585ee-c9e9-4704-ba6a-4b992a86b463.png)
