### PR TITLE
Make prop main functions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Download the correct UF2 file from the list above and install it onto the board:
 Open the `config.py` file in this repo and change at least the following properties to fit to your environment:
 
 ```
+# MQTT topic names will be derived from the prop name. Make it unique acress all props
+PROP_NAME = "Prop1"
+
 # WIFI details for Raspberry PI Pico W
 WIFI_SSID = "your-ssid"
 WIFI_PASSWORD = "your-secret"
@@ -37,19 +40,32 @@ MQTT_SERVER_HOST="192.168.1.66"
 # Make the MQTT client ID unique across all the props
 MQTT_CLIENT_ID="Wiznet W5100S-EVB-Pico ETH 1"
 
+# Topic patters need be in sync with your room server settings
+MQTT_TOPIC_PREFIX = "Room/TestRoom"
+
 # Topics to receive messages from
 MQTT_TOPICS_TO_SUBSCRIBE = [
-    "Room/TestRoom/Control/game:players",
-    "Room/TestRoom/Control/game:scenario",
-    "Room/TestRoom/Control/game:countdown:seconds",
-    "Room/TestRoom/Props/RandomNumber/inbox",
+    # Subscribe to topics with room server control messages
+    f"{MQTT_TOPIC_PREFIX}/Control/game:players",
+    f"{MQTT_TOPIC_PREFIX}/Control/game:scenario",
+
+    # Subscribe to the prop's own inbox topic
+    MQTT_TOPIC_PROP_INBOX,
 ]
 
-# Topics to send messages to. Make it unique across all the props
-MQTT_TOPIC_TO_PUBLISH = "Room/TestRoom/Props/Prop1/outbox"
+
+# Modify this function to do something specific on incoming MQTT messages
+def on_mqtt_message(topic: str, msg: str):
+    ...
+
+# Modify this function to do something specific in the main loop
+# Typically checking sensors, setting pin values and sending MQTT messages
+from paniq_prop.mqtt import Mqtt
+def check_sensors(prop_runtime_secs: int, mqtt: Mqtt):
+    ...
 ```
 
-If required set any other detail in the `config.py`.
+If required set other details in the `config.py`.
 
 ### 3. Transfer the project files to your board
 

--- a/config.py
+++ b/config.py
@@ -1,8 +1,8 @@
 # Make changes in this file to fit to your prop
 # Never commit secrets in this file
 
-# Prop name to identify your tap.
-# MQTT topic names to publish and receive messages will be deri this name
+# Prop name to identify your prop.
+# MQTT topic names will be derived from the prop name. Make it unique acress all props
 PROP_NAME = "Prop1"
 
 # Logfile name. Set an empty string to disable logging to file
@@ -35,7 +35,7 @@ MQTT_SERVER_KEEPALIVE = 60
 # Make the MQTT client ID unique across all the props
 MQTT_CLIENT_ID = "Wiznet W5100S-EVB-Pico ETH 1"
 
-# Common topics
+# Topic patters need be in sync with your room server settings
 MQTT_TOPIC_PREFIX = "Room/TestRoom"
 MQTT_TOPIC_PROP_INBOX = f"{MQTT_TOPIC_PREFIX}/Props/{PROP_NAME}/inbox"
 
@@ -51,3 +51,19 @@ MQTT_TOPICS_TO_SUBSCRIBE = [
 
 # Topics to send messages to. Make it unique across all the props
 MQTT_TOPIC_TO_PUBLISH = f"{MQTT_TOPIC_PREFIX}/Props/{PROP_NAME}/outbox"
+
+
+# Modify this function to do something specific on incoming MQTT messages
+def on_mqtt_message(topic: str, msg: str):
+    print(f"Custom Message received from {topic}: {msg}")
+
+
+# Modify this function to do something specific in the main loop
+# Typically checking sensors, setting pin values and sending MQTT messages
+from paniq_prop.mqtt import Mqtt
+def check_sensors(prop_runtime_secs: int, mqtt: Mqtt):
+    import time
+
+    # Example code to publish MQTT message every 5 seconds
+    if not prop_runtime_secs % 5:
+        mqtt.publish(f"DATA client_id={MQTT_CLIENT_ID} prop_runtime_secs={prop_runtime_secs} time={time.time()}")


### PR DESCRIPTION
## Description

All props need to do unique things, and it should be configurable in a common place.

## Solution description

Add two python functions to `config.py` which is loaded at startup time:
* `on_mqtt_message`: To receive and process incoming MQTT messages
* `check_sensors`: To do things in the main loop like checking sensors, setting pin values and sending MQTT messages

Both functions are python functions and configurable in `config.py` so can make props with custom and unique behaviour.

## Checklist

- [ ] Made great code
